### PR TITLE
Fix error on generating crossword

### DIFF
--- a/backend/backtracking.py
+++ b/backend/backtracking.py
@@ -33,7 +33,7 @@ def get_table(locations: list[WordLocation]) -> BackTrackTable:
         return shift_position(location.first_letter, location.type, location.length)
 
     def get_table_size() -> int:
-        return max((coord for location in locations for coord in get_last_position(location)), default=0)
+        return max((coord for location in locations for coord in get_last_position(location)), default=0) + 1
 
     return [[None for _ in range(get_table_size())] for _ in range(get_table_size())]
 

--- a/backend/generate.py
+++ b/backend/generate.py
@@ -25,8 +25,8 @@ def determine_locations(table: Table) -> list[WordLocation]:
                        for row_shift, column_shift in [[-1, 0], [0, -1], [1, 0], [0, 1]])
 
         return (getattr(position, axes.changeable) == 0 or table[previous_row][previous_column] == 0) and \
-               (getattr(position, axes.changeable) == len(
-                   table) - 1 or table[next_row][next_column] == 1) or has_no_filled_neighbours()
+               (getattr(position, axes.changeable) < len(
+                   table) - 1 and table[next_row][next_column] == 1) or has_no_filled_neighbours()
 
     locations = []
 


### PR DESCRIPTION
Fixes #112
Помилка з'являлася коли слово було в останній колонці чи рядку, бо на бекенді в такого слова кожна буква рахувалася як окреме слово (в іншому напрямку ніж саме слово), а на фронтенді - ні. Виправив бекенд.