### PR TITLE
Match the colour of the tab icons to the figma version

### DIFF
--- a/frontend/src/components/Tab/styles.scss
+++ b/frontend/src/components/Tab/styles.scss
@@ -86,7 +86,7 @@
       transform: scale(1.125);
 
       --icon-stroke: #{cl(near-black)};
-      --icon-fill: #{cl(dark)};
+      --icon-fill: #{cl(light-dark)};
     }
   }
 
@@ -103,7 +103,7 @@
 
       .icon {
         --icon-stroke: #{cl(near-black)};
-        --icon-fill: #{cl(dark)};
+        --icon-fill: #{cl(light-dark)};
       }
     }
 

--- a/frontend/src/icons/LeftArrow/styles.scss
+++ b/frontend/src/icons/LeftArrow/styles.scss
@@ -5,7 +5,7 @@
   height: var(--icon-size);
   width: var(--icon-size);
 
-  --icon-stroke: #{cl(dark, 0.67)};
+  --icon-stroke: #{cl(near-black, 0.67)};
   .icon-path {
     fill: var(--icon-stroke);
   }

--- a/frontend/src/icons/Square/styles.scss
+++ b/frontend/src/icons/Square/styles.scss
@@ -6,8 +6,8 @@
   height: var(--icon-size);
   box-sizing: border-box;
 
-  --icon-stroke: #{cl(dark, 0.67)};
-  --icon-fill: #{cl(dark, 0.67)};
+  --icon-stroke: #{cl(near-black, 0.67)};
+  --icon-fill: #{cl(light-dark, 0.67)};
   border: solid 1px var(--icon-stroke);
   border-radius: 2px;
 


### PR DESCRIPTION
Fixes #133 

Привів всі кольори іконок з `Tab` до варіантів з фігми.