### PR TITLE
Break long words in non-editable state of `TextField`

### DIFF
--- a/frontend/src/components/TextField/styles.scss
+++ b/frontend/src/components/TextField/styles.scss
@@ -12,6 +12,7 @@
         width: 100%;
         background-color: transparent;
         overflow-wrap: break-word;
+        word-break: break-word;
         border: none;
         margin: 0;
         padding: 0;


### PR DESCRIPTION
Fixes #110 