### PR TITLE
Remove `alternativeLabels` from non-selected tab

### DIFF
--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -100,7 +100,7 @@ function App() {
     return {
       label: getLabel(currentMode),
       alternativeLabels: Object.values(Mode).flatMap((tabMode) =>
-        tabMode !== currentMode && tabMode !== Mode.EnterQuestions
+        tabMode !== currentMode && tabMode !== Mode.EnterQuestions && isSelected
           ? [getLabel(tabMode)]
           : [],
       ),


### PR DESCRIPTION
Closes #135 