### PR TITLE
When `requestFailed` in `Solve` request, display `Replace questions` button instead of `Solve`

### DIFF
--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -289,6 +289,7 @@ function App() {
                         mode === Mode.EnterQuestions &&
                         questionsMode === QuestionsMode.Entered &&
                         !fetchAbortController &&
+                        !requestFailed &&
                         !showConfirmationState,
                       center: true,
                     },
@@ -302,7 +303,9 @@ function App() {
                       ),
                       display:
                         requestMode === RequestMode.Solve &&
-                        (isAnswerOrPuzzleMode || !!fetchAbortController) &&
+                        (isAnswerOrPuzzleMode ||
+                          !!fetchAbortController ||
+                          requestFailed) &&
                         !showConfirmationState,
                       center: true,
                     },

--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -335,7 +335,8 @@ function App() {
                             questions={questions[direction]}
                             isEditable={
                               mode === Mode.EnterQuestions &&
-                              !fetchAbortController
+                              !fetchAbortController &&
+                              !requestFailed
                             }
                             color={color}
                             onChange={(question, index) =>


### PR DESCRIPTION
Resolves #159 